### PR TITLE
feat(rosco): Add rosco config

### DIFF
--- a/base/kustomization.yml
+++ b/base/kustomization.yml
@@ -33,7 +33,13 @@ secretGenerator:
   files:
   - kleat/orca.yml
   name: orca-config
-- name: spinnaker-secrets
+- behavior: merge
+  files:
+  - kleat/rosco.yml
+  name: rosco-config
+- behavior: merge
+  name: spinnaker-secrets
+  files: []
 resources:
 - github.com/spinnaker/kustomization-base/core
 # - github.com/spinnaker/kustomization-base/kayenta


### PR DESCRIPTION
This commit also restores the spinnaker-secrets secret to use a merge strategy as it has been added back to the base.