### PR TITLE
fix(core): Add kustomize refs to remote bases

### DIFF
--- a/base/kustomization.yml
+++ b/base/kustomization.yml
@@ -57,9 +57,9 @@ configMapGenerator:
   envs:
   - kleat/deck.env
 resources:
-- github.com/spinnaker/kustomization-base/core
-# - github.com/spinnaker/kustomization-base/kayenta
-# - github.com/spinnaker/kustomization-base/fiat
+- github.com/spinnaker/kustomization-base/core?ref=master
+# - github.com/spinnaker/kustomization-base/kayenta?ref=master
+# - github.com/spinnaker/kustomization-base/fiat?ref=master
 commonLabels:
   app.kubernetes.io/component: server
   app.kubernetes.io/managed-by: kleat


### PR DESCRIPTION
## What

Added references of `master` to [kustomization-base](https://github.com/spinnaker/kustomization-base)'s remote bases.

## Why

To explicitly make sure it uses `master` by default. It'd help users to take care of their versions.
